### PR TITLE
Align websocket reconnect timeout with default timeout

### DIFF
--- a/ports/esp-idf/ws.c
+++ b/ports/esp-idf/ws.c
@@ -44,7 +44,7 @@
 #include "logger.h"
 
 #define DEFAULT_TIMEOUT_MS		(10U/*sec*/ * 1000)
-#define DEFAULT_RECONNECT_TIMEOUT_MS	(1U/*min*/ * 60/*sec*/ * 1000)
+#define DEFAULT_RECONNECT_TIMEOUT_MS	DEFAULT_TIMEOUT_MS
 
 #define DEFAULT_MAX_RETRY		10U
 #define DEFAULT_MAX_BACKOFF_MS		(100U * 1000)


### PR DESCRIPTION
This pull request includes a small change to the `ports/esp-idf/ws.c` file. The change modifies the `DEFAULT_RECONNECT_TIMEOUT_MS` definition to use the value of `DEFAULT_TIMEOUT_MS` instead of a separate calculation.

Changes to timeout definitions:

* [`ports/esp-idf/ws.c`](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dL47-R47): `DEFAULT_RECONNECT_TIMEOUT_MS` now uses `DEFAULT_TIMEOUT_MS` for its value.