### PR TITLE
Add unit tests for uptime module

### DIFF
--- a/tests/runners/uptime.mk
+++ b/tests/runners/uptime.mk
@@ -1,0 +1,45 @@
+# This file is part of PAZZK EVSE project <https://pazzk.net/>.
+# Copyright (c) 2024 Kyunghwan Kwon <k@libmcu.org>.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+COMPONENT_NAME = uptime
+
+SRC_FILES = \
+        ../src/uptime.c \
+
+TEST_SRC_FILES = \
+        src/uptime_test.cpp \
+        src/test_all.cpp \
+        stubs/logging.c \
+
+INCLUDE_DIRS = \
+        $(CPPUTEST_HOME)/include \
+        mocks/ \
+        ../include \
+        ../include/driver \
+        ../external/libmcu/modules/common/include \
+        ../external/libmcu/modules/logging/include \
+        ../external/libmcu/modules/metrics/include \
+        ../external/libmcu/modules/timer/include \
+        ../external/libmcu/interfaces/apptmr/include \
+        ../external/libmcu/interfaces/flash/include \
+        ../external/libmcu/interfaces/gpio/include \
+        ../external/libmcu/interfaces/pwm/include \
+        ../external/libmcu/interfaces/spi/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS = -include ../include/logger.h \
+        -DMETRICS_USER_DEFINES=\"../include/metrics.def\" \
+
+include runners/MakefileRunner

--- a/tests/src/uptime_test.cpp
+++ b/tests/src/uptime_test.cpp
@@ -1,0 +1,55 @@
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+extern "C" {
+    #include "uptime.h"
+    #include <time.h>
+}
+
+// Mock for time function
+extern "C" {
+    time_t mock_time = 0;
+    
+    time_t time(time_t *tloc) {
+        if (tloc != NULL) {
+            *tloc = mock_time;
+        }
+        return mock_time;
+    }
+}
+
+TEST_GROUP(uptime) {
+    void setup() {
+        mock_time = 1000; // Start with a non-zero time
+        uptime_init();
+    }
+
+    void teardown() {
+        mock().checkExpectations();
+        mock().clear();
+    }
+};
+
+TEST(uptime, ShouldReturnZeroUptimeInitially) {
+    // After initialization, uptime should be 0
+    time_t result = uptime_get();
+    LONGS_EQUAL(0, result);
+}
+
+TEST(uptime, ShouldReturnCorrectUptimeAfterTimeChange) {
+    // Advance the mock time by 60 seconds
+    mock_time += 60;
+    
+    // Uptime should now be 60 seconds
+    time_t result = uptime_get();
+    LONGS_EQUAL(60, result);
+}
+
+TEST(uptime, ShouldHandleLargeTimeValues) {
+    // Set a large time value
+    mock_time += 86400; // 1 day
+    
+    // Uptime should be 1 day
+    time_t result = uptime_get();
+    LONGS_EQUAL(86400, result);
+}


### PR DESCRIPTION
This PR adds unit tests for the uptime module to increase test coverage. The tests verify that the uptime module correctly tracks system uptime.