### PR TITLE
fix(main): adjust WDT timeout and improve tag handling

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -21,10 +21,14 @@ jobs:
       - name: Get latest tag or PR base branch
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            TAG_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
-          else
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            TAG_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+            if [[ -z "$TAG_VERSION" ]]; then
+              echo "No valid tags found. Setting TAG_VERSION to 'unknown'."
+              TAG_VERSION="unknown"
+            fi
           fi
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 

--- a/src/charger/ocpp/csms.c
+++ b/src/charger/ocpp/csms.c
@@ -53,7 +53,7 @@
 #define RXQUEUE_SIZE			4096
 
 #define DEFAULT_WS_PING_INTERVAL_SEC	300
-#define DEFAULT_TX_TIMEOUT_MS		10000
+#define DEFAULT_TX_TIMEOUT_MS		8000
 #define DEFAULT_SERVER_URL		"wss://csms.pazzk.net"
 
 static_assert(sizeof(((struct config *)0)->net.server_url) == WS_URI_MAXLEN,

--- a/src/main.c
+++ b/src/main.c
@@ -66,7 +66,7 @@
 #define METRIC_STORAGE_MAXLEN		720 /* 30-day worth of data */
 #define METRIC_PREFIX			"metrics"
 
-#define RUNNER_WDT_TIMEOUT_MS		(1U/*sec*/ * 1000)
+#define RUNNER_WDT_TIMEOUT_MS		(10U/*sec*/ * 1000)
 #define CLEANUP_TIMEOUT_MS		(2U/*sec*/ * 1000)
 
 static uint8_t actor_mem[ACTOR_MEMSIZE_BYTES];


### PR DESCRIPTION
This pull request includes several changes aimed at improving the codebase's functionality and reliability. The most important changes involve adjustments to the version checking workflow, modifications to timeout settings, and enhancements to error handling.

### Workflow improvements:

* [`.github/workflows/check-version.yml`](diffhunk://#diff-8afe568f7bca31f3457ff9b8e7fc829ac3918722cb3c77aa85b59c197b113664L24-R31): Updated the logic for determining the `TAG_VERSION` to handle cases where no valid tags are found, setting `TAG_VERSION` to "unknown" if necessary.

### Timeout adjustments:

* [`src/charger/ocpp/csms.c`](diffhunk://#diff-075a4f4da7eb418db049ef186579f4c769a8bb965696bd1eea6413752e0be6d7L56-R56): Reduced the `DEFAULT_TX_TIMEOUT_MS` from 10000 milliseconds to 8000 milliseconds to improve performance.
* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L69-R69): Increased the `RUNNER_WDT_TIMEOUT_MS` from 1 second to 10 seconds to allow more time for the runner process to complete before triggering a watchdog timeout.