### PR TITLE
fix(ws): correct base64 encoding and update libmcu submodule

### DIFF
--- a/ports/host/ws.c
+++ b/ports/host/ws.c
@@ -86,7 +86,9 @@ static void add_basic_auth_header(struct ws_server *ws,
 	const int len = snprintf(ws->header, sizeof(ws->header), "Basic ");
 	const size_t needed = (((size_t)b_len + 2) / 3) * 4;
 	if (len > 0 && b_len > 0 && (size_t)len + needed < sizeof(ws->header)) {
-		size_t n = base64_encode(&ws->header[len], b, (size_t)b_len);
+		const size_t cap = sizeof(ws->header) - (size_t)len;
+		const size_t n = lm_base64_encode(&ws->header[len], cap,
+				b, (size_t)b_len);
 		ws->header[(size_t)len + n] = '\0';
 
 		uint8_t **p = (uint8_t **)in;


### PR DESCRIPTION
This pull request includes updates to a submodule and a function in the `ws.c` file to improve functionality and maintainability. The most important changes involve updating the `libmcu` submodule to a new commit and replacing a base64 encoding function with a safer alternative.

### Submodule update:
* Updated the `libmcu` submodule to commit `0fe8aee004539a5ded0f335b06a98201fc46a264`, reflecting the latest changes in the external dependency.

### Code improvement:
* In the `add_basic_auth_header` function in `ws.c`, replaced the `base64_encode` function with `lm_base64_encode`, which includes additional parameters for specifying buffer size, improving safety and preventing potential buffer overflows.