### PR TITLE
feat(metering): add calibration parameter support

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 821740	 188324	1862245	2872309	 2bd3f5	build/EVSE.elf
+ 823704	 188420	1862245	2874369	 2bdc01	build/EVSE.elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           $IDF_PATH/tools/idf_tools.py install xtensa-clang
           . $IDF_PATH/export.sh
-          pip3 install codechecker
+          pip3 install codechecker==6.25.1
           sed -i 's/-fno-tree-switch-conversion//g' build/compile_commands.json
           sed -i 's/-fstrict-volatile-bitfields//g' build/compile_commands.json
           sed -i 's/-std=gnu17//g' build/compile_commands.json

--- a/docs/markdown/development_board.md
+++ b/docs/markdown/development_board.md
@@ -92,7 +92,7 @@ personal use. It is also well-suited for custom charger builds and DIY projects.
 | Ground Fault Detection        | 13                                      | mA          |
 | Input Voltage Range           | 100 – 300                               | VAC         |
 | Power Measurement Accuracy    | ±0.5                                    | %           |
-| Operating Temperature         | -30 to +70                              | °C          |
+| Operating Temperature         | -30 to +55                              | °C          |
 | Storage Temperature           | -40 to +85                              | °C          |
 | Dimensions (L × W × H)        | 110 x 125.58 x 54.53                    | mm          |
 | Weight                        | 302                                     | g           |
@@ -225,7 +225,7 @@ OCPP 인증과 화재예방형 충전기 인증은 직접 대행도 가능합니
 | Ground Fault Detection        | 13                                      | mA          |
 | Input Voltage Range           | 100 – 300                               | VAC         |
 | Power Measurement Accuracy    | ±0.5                                    | %           |
-| Operating Temperature         | -30 to +70                              | °C          |
+| Operating Temperature         | -30 to +55                              | °C          |
 | Storage Temperature           | -40 to +85                              | °C          |
 | Dimensions (L × W × H)        | 110 x 125.58 x 54.53                    | mm          |
 | Weight                        | 302                                     | g           |

--- a/include/metering.h
+++ b/include/metering.h
@@ -55,6 +55,10 @@ extern "C" {
 #define METERING_ENERGY_SAVE_INTERVAL_MIN	5 /* 5 minutes */
 #endif
 
+#if !defined(METERING_CALIBRATION_TOTAL_SIZE)
+#define METERING_CALIBRATION_TOTAL_SIZE		22
+#endif
+
 typedef enum {
 	METERING_HLW811X,
 } metering_t;

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -40,6 +40,7 @@
 #include "libmcu/metrics.h"
 #include "libmcu/crc32.h"
 
+#include "metering.h" /* for METERING_CALIBRATION_TOTAL_SIZE */
 #include "logger.h"
 
 #define NAMESPACE			"config"
@@ -119,6 +120,7 @@ static const struct config_custom_entry custom_config_map[] = {
 	  "123456789012345" */
 	{ "x509.ca",         CONFIG_X509_MAXLEN }, /* CA certificates */
 	{ "x509.cert",       CONFIG_X509_MAXLEN }, /* Device certificate */
+	{ "mtr.cal.ch1",     METERING_CALIBRATION_TOTAL_SIZE },
 };
 
 static struct config_mgr mgr;

--- a/tests/src/config_test.cpp
+++ b/tests/src/config_test.cpp
@@ -204,6 +204,9 @@ TEST(Config, ShouldResetAllConfigsToDefault_WhenNullKeyGiven) {
 	mock().expectOneCall("clear")
 		.withStringParameter("key", "x509.cert")
 		.andReturnValue(0);
+	mock().expectOneCall("clear")
+		.withStringParameter("key", "mtr.cal.ch1")
+		.andReturnValue(0);
 	config_reset(NULL);
 }
 TEST(Config, ShouldResetSpecificConfigToDefault_WhenKeyGiven) {


### PR DESCRIPTION
This pull request introduces changes to improve the calibration and configuration of the HLW8112 metering adapter, updates documentation to reflect revised operating temperature specifications, and updates a submodule reference. Below is a summary of the most important changes grouped by theme:

### Metering Calibration Enhancements:
* Added a new `METERING_CALIBRATION_TOTAL_SIZE` macro in `metering.h` to define the size of calibration parameters.
* Updated `config.c` to include metering calibration parameters in the configuration map using the new macro. [[1]](diffhunk://#diff-283da1238ae15652e1c38ba5bd7660e6690540dd48a6fa8720b30cc3a8727f8dR43) [[2]](diffhunk://#diff-283da1238ae15652e1c38ba5bd7660e6690540dd48a6fa8720b30cc3a8727f8dR123)
* Introduced a `cal_param` structure in `hlw8112.c` to represent calibration parameters, ensured it matches the defined size, and added a static assertion to validate the size.
* Added the `apply_calibration` function in `hlw8112.c` to fetch and apply calibration parameters from configuration storage. This replaces hardcoded calibration values in the `enable` function.

### Documentation Updates:
* Updated the operating temperature range in `development_board.md` to reflect a new maximum of +55°C instead of +70°C. [[1]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL95-R95) [[2]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL228-R228)

### Submodule Update:
* Updated the `hlw811x` submodule reference to a newer commit (`770cdb58f038d1acf17a97cd4ed7f8d620329539`).