### PR TITLE
Add default port retrieval for protocols and update default server url

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 823808	 188452	1862245	2874505	 2bdc89	build/EVSE.elf
+ 823812	 188452	1862245	2874509	 2bdc8d	build/EVSE.elf

--- a/src/charger/extension_ocpp.c
+++ b/src/charger/extension_ocpp.c
@@ -152,7 +152,6 @@ static void proc_remote_reset(struct charger *charger,
 {
 	ocpp_charger_reboot_t type = (ocpp_charger_reboot_t)
 		(uintptr_t)msg->value;
-	ocpp_charger_request_reboot(charger, type);
 	charger_iterate_connectors(charger, on_each_connector_reboot, &type);
 }
 

--- a/src/charger/ocpp/csms.c
+++ b/src/charger/ocpp/csms.c
@@ -54,7 +54,7 @@
 
 #define DEFAULT_WS_PING_INTERVAL_SEC	300
 #define DEFAULT_TX_TIMEOUT_MS		8000
-#define DEFAULT_SERVER_URL		"wss://csms.pazzk.net"
+#define DEFAULT_SERVER_URL		"wss://ocpp.pazzk.net:9000"
 
 static_assert(sizeof(((struct config *)0)->net.server_url) == WS_URI_MAXLEN,
 		"WS_URI_MAXLEN is not equal to the size of ws_param.url");

--- a/src/charger/ocpp/handler.c
+++ b/src/charger/ocpp/handler.c
@@ -378,12 +378,13 @@ static void do_reset(struct ocpp_charger *charger,
 {
 	const struct ocpp_Reset *p = (const struct ocpp_Reset *)
 		message->payload.fmt.request;
+	const ocpp_charger_reboot_t type = (p->type == OCPP_RESET_HARD)?
+		OCPP_CHARGER_REBOOT_FORCED :
+		OCPP_CHARGER_REBOOT_REQUIRED_REMOTELY;
 
+	ocpp_charger_request_reboot((struct charger *)charger, type);
 	ocpp_charger_mq_send((struct charger *)charger,
-			OCPP_CHARGER_MSG_REMOTE_RESET,
-			(p->type == OCPP_RESET_HARD)?
-				(void *)OCPP_CHARGER_REBOOT_FORCED :
-				(void *)OCPP_CHARGER_REBOOT_REQUIRED_REMOTELY);
+			OCPP_CHARGER_MSG_REMOTE_RESET, (void *)type);
 
 	csms_response(OCPP_MSG_RESET, message, NULL, charger);
 }


### PR DESCRIPTION
This pull request introduces several changes across documentation, network utility functions, and OCPP charger handling. The most significant updates include adjustments to default port handling in network utilities, modifications to OCPP charger reboot logic, and updates to documentation regarding device identification and EVSE development board specifications.

### Documentation Updates:
* [`docs/markdown/development_board.md`](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL16-R16): Updated specifications for the EVSE Development Board, reducing the rated AC power output from 11 kW to 7 kW and clarifying descriptions in both English and Korean sections. [[1]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL16-R16) [[2]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL90-R89) [[3]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL141-R140) [[4]](diffhunk://#diff-c29fb848204693317dd626de114a72eb94098136938153aacc33bb6d6573c68eL223-R221)
* [`docs/markdown/device_serial_number.md`](diffhunk://#diff-47f078e24e65ac8096fc7827242187d942e9ad9e3c627a560b3833348a0536faR51-R93): Added a detailed section explaining the use of `SAN` vs `CN` in TLS certificates, including examples and best practices for device identification.

### Network Utility Enhancements:
* [`include/net/util.h`](diffhunk://#diff-8df5d30e15dd1a25740d77b5a65605071297d460fa4acd4ae65f85cf10ccbed2R62-R71): Introduced `net_get_default_port` function to retrieve default port numbers based on network protocol.
* [`src/net/util.c`](diffhunk://#diff-f1caff8e35929e70a7c8dd7ef055ab8b515958230f455490a684a2dcc49582f6R61-R86): Implemented logic for `net_get_default_port` and updated `net_get_port_from_url` to fallback to default ports when none are specified in the URL. [[1]](diffhunk://#diff-f1caff8e35929e70a7c8dd7ef055ab8b515958230f455490a684a2dcc49582f6R61-R86) [[2]](diffhunk://#diff-f1caff8e35929e70a7c8dd7ef055ab8b515958230f455490a684a2dcc49582f6L107-R133)
* [`tests/src/net/util_test.cpp`](diffhunk://#diff-6e5f378c987c1aa418f824b427d0930d378ba400ad8e1c64e89d9e2e2df0049bL258-R258): Adjusted test cases to reflect the new default port behavior in `net_get_port_from_url`.

### OCPP Charger Logic Updates:
* [`src/charger/extension_ocpp.c`](diffhunk://#diff-31c6326397de5ad37e271ffdf9ee037369d2c8a317b2a690cb11fcdc00abc90aL155): Removed direct reboot request and replaced it with connector iteration logic for handling remote resets.
* [`src/charger/ocpp/handler.c`](diffhunk://#diff-bf5d4fd43f1917f7d019036c8373691abf6286f2aa411bdeadac4a89bb069651R381-R387): Refactored reset logic to use `ocpp_charger_request_reboot` with a more structured approach to determine reboot type.

### Configuration Changes:
* [`src/charger/ocpp/csms.c`](diffhunk://#diff-075a4f4da7eb418db049ef186579f4c769a8bb965696bd1eea6413752e0be6d7L57-R57): Updated the default server URL for OCPP communication to use a new domain and port (`wss://ocpp.pazzk.net:9000`).