### PR TITLE
fix(updater): handle pending state with date check

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 823812	 188452	1862245	2874509	 2bdc8d	build/EVSE.elf
+ 823892	 188484	1862245	2874621	 2bdcfd	build/EVSE.elf

--- a/ports/host/ws.c
+++ b/ports/host/ws.c
@@ -214,8 +214,7 @@ static int connect_to_server(struct server *srv)
 
 	if (net_is_secure_protocol(net_get_protocol_from_url(ws->param.url))) {
 		ws->conn_info.ssl_connection =
-			LCCSCF_USE_SSL | LCCSCF_ALLOW_SELFSIGNED |
-			LCCSCF_SKIP_SERVER_CERT_HOSTNAME_CHECK;
+			LCCSCF_USE_SSL | LCCSCF_ALLOW_SELFSIGNED;
 	}
 
 	info("connecting to %s:%d%s", ws->host, ws->conn_info.port, ws->path);

--- a/src/main.c
+++ b/src/main.c
@@ -236,6 +236,7 @@ static bool update(void *ctx)
 	if (updater_process() == -EAGAIN) {
 		return true;
 	}
+	debug("Updater finished");
 	return false;
 }
 

--- a/src/updater.c
+++ b/src/updater.c
@@ -306,7 +306,10 @@ int updater_process(void)
 	updater_event_t event = UPDATER_EVT_NONE;
 
 	if (!is_updating(&updater)) {
-		if (is_pending(&updater) && has_date_arrived(&updater, &now)) {
+		if (is_pending(&updater)) {
+			if (!has_date_arrived(&updater, &now)) {
+				return -EAGAIN; /* not yet arrived */
+			}
 			pthread_mutex_lock(&updater.lock);
 			event = start_download(&updater, &now);
 			pthread_mutex_unlock(&updater.lock);

--- a/tests/src/updater_test.cpp
+++ b/tests/src/updater_test.cpp
@@ -144,13 +144,13 @@ TEST(updater, ShouldCallRunnerWithContext_WhenContextGiven) {
 TEST(updater, ShouldReturnZero_WhenNoRequest) {
 	LONGS_EQUAL(0, updater_process());
 }
-TEST(updater, ShouldReturnZero_WhenPending) {
+TEST(updater, ShouldReturnEAGAIN_WhenPending) {
 	struct downloader *downloader = (struct downloader *)0x1234;
         struct updater_param param = {
 		.retrieve_date = time(NULL) + 1,
 	};
 	updater_request(&param, downloader);
-	LONGS_EQUAL(0, updater_process());
+	LONGS_EQUAL(-EAGAIN, updater_process());
 }
 TEST(updater, ShouldReturnZero_WhenDfuNewFailed) {
 	struct downloader *downloader = (struct downloader *)0x1234;


### PR DESCRIPTION
This pull request refines the logic in the `updater_process` function within `src/updater.c`. The change adds a new condition to improve the handling of pending updates by introducing an early return when the update date has not yet arrived.

Key change in update processing logic:

* [`src/updater.c`](diffhunk://#diff-486c8f3f5cd1531a7ad31ca11ec87e3111e7c865d109a1127f174fbca77f87c3L309-R312): Modified the `updater_process` function to check if the update date has arrived before proceeding with the download. If the date has not arrived, the function now returns `-EAGAIN` immediately, ensuring the process does not unnecessarily acquire locks or start downloads prematurely.