### PR TITLE
feat(ocpp): conditional reboot for remote and DFU updates

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 823892	 188484	1862245	2874621	 2bdcfd	build/EVSE.elf
+ 824036	 188484	1862245	2874765	 2bdd8d	build/EVSE.elf

--- a/src/app.c
+++ b/src/app.c
@@ -113,8 +113,14 @@ static void on_charger_event(struct charger *charger, struct connector *c,
 
 	if (event & OCPP_CHARGER_EVENT_REBOOT_REQUIRED) {
 		bool reboot_manually = false;
-		config_get("dfu.reboot_manually",
-				&reboot_manually, sizeof(reboot_manually));
+		const ocpp_charger_reboot_t req =
+			ocpp_charger_get_pending_reboot_type(charger);
+
+		if (req == OCPP_CHARGER_REBOOT_REQUIRED) {
+			config_get("dfu.reboot_manually", &reboot_manually,
+					sizeof(reboot_manually));
+		}
+
 		if (!reboot_manually) {
 			app_reboot();
 		}

--- a/src/charger/extension_ocpp.c
+++ b/src/charger/extension_ocpp.c
@@ -100,6 +100,20 @@ static void on_each_connector_reboot(struct connector *c, void *ctx)
 			*type == OCPP_CHARGER_REBOOT_FORCED);
 }
 
+static void on_connector_state_check(struct connector *c, void *ctx)
+{
+	const ocpp_connector_state_t state =
+		ocpp_connector_state((struct ocpp_connector *)c);
+
+	if (state == Charging || state == SuspendedEV || state == SuspendedEVSE) {
+		bool *charging = (bool *)ctx;
+
+		if (charging) {
+			*charging = true;
+		}
+	}
+}
+
 static void dispatch_event(struct charger *charger, struct connector *c,
 		const charger_event_t event)
 {
@@ -238,7 +252,23 @@ static int ext_pre_process(struct charger *self)
 
 static int ext_post_process(struct charger *self)
 {
-	unused(self);
+	const ocpp_charger_reboot_t req =
+		ocpp_charger_get_pending_reboot_type(self);
+
+	if (req != OCPP_CHARGER_REBOOT_NONE &&
+			ocpp_count_pending_requests() == 0) {
+		if (req == OCPP_CHARGER_REBOOT_REQUIRED) { /* triggered by DFU.
+						Do not reboot during charging */
+			bool charging = false;
+			charger_iterate_connectors(self,
+					on_connector_state_check, &charging);
+			if (charging) {
+				return 0;
+			}
+		}
+		dispatch_event(self, NULL, OCPP_CHARGER_EVENT_REBOOT_REQUIRED);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of charger reboot events and enhance the logic for processing pending reboot requests. The updates ensure that reboot-related operations are triggered only under specific conditions and streamline the event dispatch process.

### Improvements to charger reboot logic:

* **Conditional retrieval of reboot type in `on_charger_event`:** Added logic to retrieve the pending reboot type (`ocpp_charger_get_pending_reboot_type`) and check if it matches `OCPP_CHARGER_REBOOT_REQUIRED` before fetching the `dfu.reboot_manually` configuration. This ensures that the reboot configuration is only accessed when necessary. (`src/app.c`, [src/app.cL116-R123](diffhunk://#diff-134a86dbc1bcb1856730147230bcaa21a569e2d4c72c9d724485dda5d03058f3L116-R123))

### Enhancements to event dispatch:

* **Event dispatch for pending reboot requests in `ext_post_process`:** Updated the function to check if there is a pending reboot request (`ocpp_charger_get_pending_reboot_type`) and no other pending requests (`ocpp_count_pending_requests`). If these conditions are met, the `OCPP_CHARGER_EVENT_REBOOT_REQUIRED` event is dispatched. This improves the accuracy of reboot event handling. (`src/charger/extension_ocpp.c`, [src/charger/extension_ocpp.cL241-R248](diffhunk://#diff-31c6326397de5ad37e271ffdf9ee037369d2c8a317b2a690cb11fcdc00abc90aL241-R248))