### PR TITLE
feat(ci): add SonarCloud workflow for code analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Install ESP-IDF
       run: |
-        git clone --recursive https://github.com/espressif/esp-idf.git ~/esp-idf
+        git clone --branch v5.4 --recursive https://github.com/espressif/esp-idf.git ~/esp-idf
         ~/esp-idf/install.sh
     
     # If the analyze step fails for one of the languages you are analyzing with

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,59 @@
+name: sonarCloud
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  sonarCloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    container: espressif/idf:v5.4
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
+      - name: Run build-wrapper
+        run: |
+          git config --system --add safe.directory "$(pwd)"
+          . $IDF_PATH/export.sh
+          idf.py set-target esp32s3
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} \
+              idf.py build -DTARGET_PLATFORM=esp32s3
+        env:
+          TARGET_PLATFORM: esp32s3
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y autoconf automake libtool
+      - name: Build coverage results
+        run: |
+          make -C tests install
+          make -C tests
+          make -C tests gcov
+          mkdir -p coverage_report
+          cp -R tests/gcov/*.gcov coverage_report/
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner \
+              --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+              --define sonar.organization=pazzk-labs \
+              --define sonar.projectKey=pazzk-labs_evse \
+              --define sonar.sources=src,ports \
+              --define sonar.tests=tests \
+              --define sonar.test.inclusions=**/*_test.cpp \
+              --define sonar.cfamily.gcov.reportsPath=coverage_report


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to integrate SonarCloud analysis for code quality and coverage reporting. The workflow is designed to run on pushes and pull requests targeting the `main` branch.

### SonarCloud Integration:

* [`.github/workflows/sonarcloud.yml`](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR1-R51): Added a new workflow named `sonarCloud` to perform SonarCloud scans. It includes steps for cloning the repository, installing necessary tools, running build-wrapper, generating coverage reports, and executing the SonarCloud scanner with appropriate configurations.