### PR TITLE
Add unused variable handling

### DIFF
--- a/ports/esp-idf/dfu.c
+++ b/ports/esp-idf/dfu.c
@@ -53,6 +53,8 @@ bool dfu_is_valid_header(const struct dfu_image_header *header)
 dfu_error_t dfu_write(struct dfu *dfu, uint32_t offset,
 		const void *data, size_t datasize)
 {
+	unused(offset);
+
 	if (esp_ota_write(dfu->ota_handle, data, datasize) != ESP_OK) {
 		metrics_increase(DFUIOErrorCount);
 		return DFU_ERROR_IO;
@@ -103,6 +105,8 @@ dfu_error_t dfu_commit(struct dfu *dfu)
 
 struct dfu *dfu_new(size_t data_block_size)
 {
+	unused(data_block_size);
+
 	metrics_increase(DFURequestCount);
 	struct dfu *p = (struct dfu *)calloc(1, sizeof(struct dfu));
 

--- a/ports/esp-idf/eth_w5500.c
+++ b/ports/esp-idf/eth_w5500.c
@@ -184,6 +184,9 @@ static void set_static_ip_if_required(struct netif *netif)
 static void on_eth_event(void *arg, esp_event_base_t event_base,
 		int32_t event_id, void *event_data)
 {
+	unused(event_base);
+	unused(event_data);
+
 	struct netif *netif = (struct netif *)arg;
 	netif_event_t netif_event = NETIF_EVENT_UNKNOWN;
 
@@ -212,6 +215,9 @@ static void on_eth_event(void *arg, esp_event_base_t event_base,
 static void on_ip_event(void *arg, esp_event_base_t event_base,
 		int32_t event_id, void *event_data)
 {
+	unused(event_base);
+	unused(event_id);
+
 	struct netif *netif = (struct netif *)arg;
 	ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
 	const esp_netif_ip_info_t *ip_info = &event->ip_info;
@@ -423,6 +429,8 @@ static int deinit(struct netif *netif)
 
 struct netif *eth_w5500_create(struct lm_spi_device *spi)
 {
+	unused(spi);
+
 	static struct netif netif = {
 		.api = {
 			.init = init,

--- a/ports/esp-idf/flash.c
+++ b/ports/esp-idf/flash.c
@@ -49,6 +49,8 @@ static const esp_partition_t *get_partition(void)
 
 static int do_erase(struct flash *self, uintptr_t offset, size_t size)
 {
+	unused(self);
+
 	const esp_partition_t *partition = get_partition();
 
 	if (partition == NULL) {
@@ -63,6 +65,8 @@ static int do_erase(struct flash *self, uintptr_t offset, size_t size)
 static int do_write(struct flash *self,
 		uintptr_t offset, const void *data, size_t len)
 {
+	unused(self);
+
 	const esp_partition_t *partition = get_partition();
 
 	if (partition == NULL) {
@@ -76,6 +80,8 @@ static int do_write(struct flash *self,
 
 static int do_read(struct flash *self, uintptr_t offset, void *buf, size_t len)
 {
+	unused(self);
+
 	const esp_partition_t *partition = get_partition();
 
 	if (partition == NULL) {

--- a/ports/esp-idf/ping.c
+++ b/ports/esp-idf/ping.c
@@ -53,6 +53,8 @@ static void on_ping_success(esp_ping_handle_t hdl, void *args)
 
 static void on_ping_timeout(esp_ping_handle_t hdl, void *args)
 {
+	unused(hdl);
+
 	struct cb_ctx *ctx = (struct cb_ctx *)args;
 	ctx->err = -ETIMEDOUT;
 }

--- a/ports/esp-idf/ws.c
+++ b/ports/esp-idf/ws.c
@@ -84,7 +84,8 @@ static bool on_websocket_error(void *ctx)
 	uint32_t backoff_ms;
 
 	if (retry_first(&ws->retry)) {
-		retry_backoff(&ws->retry, &backoff_ms, board_random());
+		retry_backoff(&ws->retry, &backoff_ms,
+				(uint16_t)board_random());
 	} else {
 		backoff_ms = retry_get_backoff(&ws->retry);
 	}
@@ -102,8 +103,8 @@ static bool on_websocket_error(void *ctx)
 	server_enable((struct server *)ws);
 	info("websocket restarted.");
 
-	if (retry_backoff(&ws->retry, &backoff_ms, board_random())
-			== RETRY_ERROR_EXHAUSTED) {
+	if (retry_backoff(&ws->retry, &backoff_ms,
+			(uint16_t)board_random()) == RETRY_ERROR_EXHAUSTED) {
 		/* TODO: notify the user that the max retry is reached
 		 * and reboot the system after cleanup. */
 		error("ws retry exhausted.");
@@ -148,6 +149,8 @@ static void on_net_event(const netmgr_state_t event, void *ctx)
 static void on_ws_event(void *ctx,
 		esp_event_base_t base, int32_t event_id, void *event_data)
 {
+	unused(base);
+
 	const esp_websocket_event_data_t *data =
 		(esp_websocket_event_data_t *)event_data;
 	struct ws_server *ws = (struct ws_server *)ctx;

--- a/src/charger/ocpp/decoder_json.c
+++ b/src/charger/ocpp/decoder_json.c
@@ -443,7 +443,7 @@ static decoder_handler_t decoder(ocpp_message_t msgtype)
 	}
 
 	error("No decoder found for %s", ocpp_stringify_type(msgtype));
-	return do_error;
+	return &do_error;
 }
 
 static int decode(struct ocpp_message *msg, cJSON *json)


### PR DESCRIPTION
This pull request primarily introduces minor code improvements across several files to enhance code readability and maintainability. It includes the addition of `unused` macro calls for unused function parameters and a type adjustment in a return statement. These changes ensure compliance with coding standards and prevent compiler warnings.

### Code readability improvements:

* **Addition of `unused` macro for unused parameters:**
  - Added `unused(offset)` in `dfu_write` to indicate the unused parameter. (`ports/esp-idf/dfu.c`, [ports/esp-idf/dfu.cR56-R57](diffhunk://#diff-f9c680b0d07407dd0b78fc7ca1fd00bf15e6d7090ced1777cea7311b7e00ce66R56-R57))
  - Added `unused(data_block_size)` in `dfu_new` to mark the unused parameter. (`ports/esp-idf/dfu.c`, [ports/esp-idf/dfu.cR108-R109](diffhunk://#diff-f9c680b0d07407dd0b78fc7ca1fd00bf15e6d7090ced1777cea7311b7e00ce66R108-R109))
  - Added `unused(event_base)` and `unused(event_data)` in `on_eth_event`. (`ports/esp-idf/eth_w5500.c`, [ports/esp-idf/eth_w5500.cR187-R189](diffhunk://#diff-9b61832af1bf2f03719168417fabb07bb9c0455349cc510f1984af450c0974d7R187-R189))
  - Added `unused(event_base)` and `unused(event_id)` in `on_ip_event`. (`ports/esp-idf/eth_w5500.c`, [ports/esp-idf/eth_w5500.cR218-R220](diffhunk://#diff-9b61832af1bf2f03719168417fabb07bb9c0455349cc510f1984af450c0974d7R218-R220))
  - Added `unused(spi)` in `eth_w5500_create`. (`ports/esp-idf/eth_w5500.c`, [ports/esp-idf/eth_w5500.cR432-R433](diffhunk://#diff-9b61832af1bf2f03719168417fabb07bb9c0455349cc510f1984af450c0974d7R432-R433))
  - Added `unused(self)` in `do_erase`, `do_write`, and `do_read` functions to indicate unused parameters. (`ports/esp-idf/flash.c`, [[1]](diffhunk://#diff-a7038132380f967a25719f39f7fe09c6e2b07acda6c6820c6b91a10c2308d71aR52-R53) [[2]](diffhunk://#diff-a7038132380f967a25719f39f7fe09c6e2b07acda6c6820c6b91a10c2308d71aR68-R69) [[3]](diffhunk://#diff-a7038132380f967a25719f39f7fe09c6e2b07acda6c6820c6b91a10c2308d71aR83-R84)
  - Added `unused(hdl)` in `on_ping_timeout`. (`ports/esp-idf/ping.c`, [ports/esp-idf/ping.cR56-R57](diffhunk://#diff-cb6373a4cec74715e14f6af2211b2f3a506f02c8e800b5ef995cdaa92e6647b7R56-R57))
  - Added `unused(base)` in `on_ws_event`. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR152-R153](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR152-R153))

### Type adjustment:

* **Modified return statement to use a pointer:**
  - Changed `return do_error` to `return &do_error` in `decoder` to ensure the correct type is returned. (`src/charger/ocpp/decoder_json.c`, [src/charger/ocpp/decoder_json.cL446-R446](diffhunk://#diff-58c8fde8ee5fde1ce3e4d8e9d14f26652e1d61d81e08770fc240804d9eeb2258L446-R446))

### Code correctness:

* **Casting for type safety:**
  - Added explicit casting of `board_random()` to `uint16_t` in `retry_backoff` calls for type consistency. (`ports/esp-idf/ws.c`, [[1]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dL87-R88) [[2]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dL105-R107)