### PR TITLE
fix(ocpp): load OCPP config after initialization

### DIFF
--- a/src/charger/ocpp/adapter.c
+++ b/src/charger/ocpp/adapter.c
@@ -311,7 +311,8 @@ static int do_get_configuration(struct ocpp_connector *c,
 	size_t req_keylen = 0;
 
 	if (req->payload.fmt.request) {
-		req_keylen = strlen((const char *)req->payload.fmt.request);
+		req_keylen = strlen(((const struct ocpp_GetConfiguration *)
+			req->payload.fmt.request)->keys);
 	}
 
 	const size_t total_size = req_keylen + 1;
@@ -324,7 +325,9 @@ static int do_get_configuration(struct ocpp_connector *c,
 	/* NOTE: An ad-hoc method of passing the request message to
 	 * be processed by the encoder. */
 	if (req_keylen) {
-		strcpy(p, (char *)req->payload.fmt.data);
+		strncpy(p, ((const struct ocpp_GetConfiguration *)
+			req->payload.fmt.request)->keys, req_keylen);
+		p[req_keylen] = '\0';
 	}
 
 	return request_free_if_fail(msg_type, req, p, total_size,

--- a/src/charger/ocpp/csms.c
+++ b/src/charger/ocpp/csms.c
@@ -209,6 +209,9 @@ int csms_init(void *ctx)
 	int err = initialize_server();
 
 	if (!err) {
+		adapter_init(csms, RXQUEUE_SIZE);
+		err = ocpp_init(on_ocpp_event, ctx);
+
 		const size_t len = ocpp_compute_configuration_size();
 		void *p = calloc(1, len);
 		if (p == NULL) {
@@ -222,9 +225,6 @@ int csms_init(void *ctx)
 		}
 
 		free(p);
-
-		adapter_init(csms, RXQUEUE_SIZE);
-		err = ocpp_init(on_ocpp_event, ctx);
 	}
 
 	return err;

--- a/src/cli/cmd_config.c
+++ b/src/cli/cmd_config.c
@@ -118,7 +118,7 @@ static void print_ocpp(const struct cli_io *io)
 	printini(io, "ocpp.model", buf);
 
 	uint32_t version;
-	config_get(buf, &version, sizeof(version));
+	config_get("ocpp.version", &version, sizeof(version));
 	snprintf(buf, sizeof(buf), "v%"PRIu32".%"PRIu32".%"PRIu32,
 			GET_VERSION_MAJOR(version), GET_VERSION_MINOR(version),
 			GET_VERSION_PATCH(version));


### PR DESCRIPTION
This pull request includes updates to improve the handling of OCPP (Open Charge Point Protocol) configuration data, streamline initialization logic, and fix a bug in the retrieval of configuration version information. The most important changes involve modifying how configuration keys are processed, refactoring initialization order in `csms_init`, and correcting a parameter in `config_get`.

### Improvements to OCPP configuration handling:

* [`src/charger/ocpp/adapter.c`](diffhunk://#diff-e70e5b04264c76ecaa19ecb052cd6c3215784e0a1ee7da316e22bc6880447a65L314-R315): Updated `do_get_configuration` to correctly extract and process configuration keys by using `struct ocpp_GetConfiguration`. This ensures safer string handling with `strncpy` and avoids potential buffer overflows. [[1]](diffhunk://#diff-e70e5b04264c76ecaa19ecb052cd6c3215784e0a1ee7da316e22bc6880447a65L314-R315) [[2]](diffhunk://#diff-e70e5b04264c76ecaa19ecb052cd6c3215784e0a1ee7da316e22bc6880447a65L327-R330)

### Refactoring initialization logic:

* [`src/charger/ocpp/csms.c`](diffhunk://#diff-075a4f4da7eb418db049ef186579f4c769a8bb965696bd1eea6413752e0be6d7R212-R214): Reordered the initialization sequence in `csms_init` to move `adapter_init` and `ocpp_init` earlier in the function, ensuring proper initialization before computing configuration size. Removed redundant code to simplify the logic. [[1]](diffhunk://#diff-075a4f4da7eb418db049ef186579f4c769a8bb965696bd1eea6413752e0be6d7R212-R214) [[2]](diffhunk://#diff-075a4f4da7eb418db049ef186579f4c769a8bb965696bd1eea6413752e0be6d7L225-L227)

### Bug fix in configuration version retrieval:

* [`src/cli/cmd_config.c`](diffhunk://#diff-eee2e4fcb0acd21cb8e6e1436472fc879e90a319d020a6b90367fadcea7ab582L121-R121): Fixed the `config_get` function call in `print_ocpp` by replacing the incorrect buffer parameter with the correct configuration key `"ocpp.version"`. This resolves a bug where the version was not being retrieved correctly.