### PR TITLE
feat(cli): enhance OCPP command with additional subcommands

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 824700	 188740	1862245	2875685	 2be125	build/EVSE.elf
+ 824868	 188868	1862245	2875981	 2be24d	build/EVSE.elf


### PR DESCRIPTION
This pull request refactors the OCPP CLI command implementation in `src/cli/cmd_ocpp.c` to improve modularity and add new subcommands for interacting with the OCPP client module. The changes include replacing hardcoded logic with a structured command array, introducing helper functions for connector iteration and state printing, and adding new subcommands for retrieving information, configurations, and pending requests.

### Refactoring and modularization:

* Replaced the previous hardcoded `DEFINE_CLI_CMD` implementation with a structured array of subcommands (`cmds`) to improve modularity. Each subcommand is now associated with a handler function (`do_info`, `do_config`, `do_pending`) for specific tasks.
* Removed redundant helper functions (`println` and `printini`) and replaced their functionality with context-aware operations using the newly introduced `struct ctx`.

### New functionality:

* Added the `info` subcommand to iterate through connectors and print their state using the `on_each_connector` helper function.
* Added the `config` subcommand to print OCPP configurations using the `print_ocpp_configurations` function.
* Added the `pending` subcommand to display the count of pending OCPP requests.

### Code cleanup:

* Updated include directives to replace outdated headers and ensure proper dependencies (`helper.h`, `charger.h`, `ocpp_connector_internal.h`, `app.h`).