### PR TITLE
feat(uid): add uid status stringification function

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 824868	 188868	1862245	2875981	 2be24d	build/EVSE.elf
+ 824960	 188948	1862245	2876153	 2be2f9	build/EVSE.elf

--- a/include/uid.h
+++ b/include/uid.h
@@ -164,6 +164,16 @@ int uid_clear(struct uid_store *store);
 int uid_register_update_cb(struct uid_store *store,
 		uid_update_cb_t cb, void *ctx);
 
+/**
+ * @brief Converts a uid_status_t value to its string representation.
+ *
+ * @param[in] status The uid_status_t value to stringify.
+ *
+ * @return A constant character pointer to the string representation
+ *         of the status.
+ */
+const char *uid_stringify_status(uid_status_t status);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/uid.c
+++ b/src/uid.c
@@ -381,6 +381,24 @@ int uid_register_update_cb(struct uid_store *store,
 	return 0;
 }
 
+const char *uid_stringify_status(uid_status_t status)
+{
+	switch (status) {
+	case UID_STATUS_ACCEPTED:
+		return "Accepted";
+	case UID_STATUS_BLOCKED:
+		return "Blocked";
+	case UID_STATUS_EXPIRED:
+		return "Expired";
+	case UID_STATUS_INVALID:
+		return "Invalid";
+	case UID_STATUS_NO_ENTRY:
+		return "No Entry";
+	default:
+		return "Unknown";
+	}
+}
+
 struct uid_store *uid_store_create(const struct uid_store_config *config)
 {
 	if (!config || !config->fs || !config->ns) {

--- a/tests/mocks/uid.cpp
+++ b/tests/mocks/uid.cpp
@@ -53,3 +53,21 @@ int uid_register_update_cb(struct uid_store *store,
 		.withPointerParameter("ctx", ctx)
 		.returnIntValue();
 }
+
+const char *uid_stringify_status(uid_status_t status)
+{
+	switch (status) {
+	case UID_STATUS_ACCEPTED:
+		return "Accepted";
+	case UID_STATUS_BLOCKED:
+		return "Blocked";
+	case UID_STATUS_EXPIRED:
+		return "Expired";
+	case UID_STATUS_INVALID:
+		return "Invalid";
+	case UID_STATUS_NO_ENTRY:
+		return "No Entry";
+	default:
+		return "Unknown";
+	}
+}


### PR DESCRIPTION
This pull request introduces a new utility function, `uid_stringify_status`, which converts `uid_status_t` values into their string representations. The function has been added to the header file, implemented in the main source file, and mirrored in the test mocks.

### New utility function for `uid_status_t`:

* [`include/uid.h`](diffhunk://#diff-c99fa33222da1f748e9d4835b182e2926995d616ac4dc712cd01b9e4c200fefdR167-R176): Declared the `uid_stringify_status` function, including documentation for its purpose and usage.
* [`src/uid.c`](diffhunk://#diff-3a56311669a439830e626640f468da3355ae919fb9080794a1400e4beb6012a6R384-R401): Implemented the `uid_stringify_status` function, mapping `uid_status_t` enum values to their corresponding string representations.
* [`tests/mocks/uid.cpp`](diffhunk://#diff-fff41d3b9410c24a1d8847b74d6dfa795212121d828f11415555f453fd9ce945R56-R73): Added a mock implementation of the `uid_stringify_status` function for testing purposes.