### PR TITLE
fix(ws): prevent repeated WebSocket restarts causing issues (#12)

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
- 826028	 189428	1862409	2877865	 2be9a9	build/EVSE.elf
+ 826060	 189428	1862409	2877897	 2be9c9	build/EVSE.elf


### PR DESCRIPTION
This pull request introduces a workaround to address a suspected WebSocket library bug, along with minor improvements for type safety and code clarity. The key changes include the addition of a conditional compile-time flag to keep the WebSocket connection enabled, adjustments to type casting for better consistency, and the use of `unused` macros to suppress unused parameter warnings.

### Workaround for WebSocket library bug:
* Introduced the `KEEP_ENABLED` compile-time flag to prevent the WebSocket module from being repeatedly closed and restarted, as this could cause unresponsiveness. Added a new `started` field to the `ws_server` struct to track initialization status. [[1]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR56-R57) [[2]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR73-R81)
* Modified the `on_net_event` function to conditionally enable or disable the WebSocket server based on the `KEEP_ENABLED` flag. This ensures the server starts only once when the flag is defined.

### Type safety improvements:
* Updated type casting in `on_ws_event` to ensure consistent use of `size_t` for `data_len`.
* Adjusted the type casting for `datasize` in the `send_data` function to explicitly cast it to `int` for compatibility with the underlying WebSocket client API.

### Code clarity:
* Added `unused` macros in `on_timeout`, `connect_to_server`, and `disconnect_from_server` functions to suppress unused parameter warnings and improve code readability. [[1]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR130) [[2]](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR262-R270)