### PR TITLE
feat(cli): add debug commands

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
-1124275	 225956	2486285	3836516	 3a8a64	build/EVSE.elf
+1125903	 226292	2487301	3839496	 3a9608	build/EVSE.elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,21 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  build-on-host:
+    name: Build on Host
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Build Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake bc vim-common
+      - name: Host Build
+        run: make PLATFORM=host
+
   build-on-esp-idf-v5_4:
     permissions:
       contents: write

--- a/ports/host/app.c
+++ b/ports/host/app.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <termios.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "libmcu/compiler.h"
 #include "libmcu/cli.h"
@@ -65,7 +66,7 @@ static void on_charger_event(struct charger *charger, struct connector *c,
 {
 	unused(c);
 	unused(ctx);
-	if (event & OCPP_CHARGER_EVENT_AVAILABILITY_CHANGED) {
+	if (event & OCPP_CHARGER_EVENT_CHECKPOINT_CHANGED) {
 		/* Availability changes are saved in non-volatile memory to keep
 		 * them persistent. */
 		const struct ocpp_checkpoint *checkpoint =
@@ -230,8 +231,9 @@ void app_init(struct app *app)
 #define CLI_MAX_HISTORY		10U
 	static char buf[CLI_CMD_MAXLEN * CLI_MAX_HISTORY];
 
-	DEFINE_CLI_CMD_LIST(commands, chg, config, exit, help, idtag, info,
-			log, net, ocpp, reboot, metric, sec, test, xmodem);
+	DEFINE_CLI_CMD_LIST(commands,
+			help, exit, reboot, info, log, metric, dbg, config, net,
+			sec, xmodem, chg, idtag, ocpp);
 
 	cli_init(&m.cli, cli_io_create(), buf, sizeof(buf), app);
 	cli_register_cmdlist(&m.cli, commands);

--- a/ports/host/apptmr.c
+++ b/ports/host/apptmr.c
@@ -98,11 +98,11 @@ static int start_apptmr(struct apptmr *self, const uint32_t timeout_ms)
 	const uint64_t usec = timeout_ms * 1000;
 
 	struct itimerspec its = {
-		.it_value.tv_nsec = usec * 1000,
+		.it_value.tv_nsec = (long)(usec * 1000),
 	};
 
 	if (self->periodic) {
-		its.it_interval.tv_nsec = usec * 1000;
+		its.it_interval.tv_nsec = (long)(usec * 1000);
 	}
 
 	return timer_settime(self->handle, 0, &its, NULL);

--- a/ports/host/flash.c
+++ b/ports/host/flash.c
@@ -51,7 +51,7 @@ static int do_erase(struct flash *self, uintptr_t offset, size_t size)
 static int do_write(struct flash *self,
 		uintptr_t offset, const void *data, size_t len)
 {
-	const uint8_t *src = data;
+	const uint8_t *src = (const uint8_t *)data;
 	uint8_t *dst = &self->storage[offset];
 	memcpy(dst, src, len);
 	return 0;

--- a/ports/host/hlw8112.c
+++ b/ports/host/hlw8112.c
@@ -31,12 +31,30 @@
  */
 
 #include "../../src/metering/adapter/hlw8112.h"
+#include "hlw811x_overrides.h"
 #include <errno.h>
+#include <stddef.h>
 #include "libmcu/compiler.h"
 
 struct metering {
 	struct metering_api api;
 };
+
+int hlw811x_ll_write(const uint8_t *data, size_t datalen, void *ctx)
+{
+	unused(data);
+	unused(datalen);
+	unused(ctx);
+	return -ENOTSUP;
+}
+
+int hlw811x_ll_read(uint8_t *buf, size_t bufsize, void *ctx)
+{
+	unused(buf);
+	unused(bufsize);
+	unused(ctx);
+	return -ENOTSUP;
+}
 
 static int get_voltage(struct metering *self, int32_t *millivolt)
 {

--- a/ports/host/nvs.c
+++ b/ports/host/nvs.c
@@ -47,7 +47,7 @@
 
 struct kvstore {
 	struct kvstore_api api;
-	const char *namespace;
+	const char *ns;
 	pthread_mutex_t lock;
 };
 
@@ -78,7 +78,7 @@ static int file_kvstore_write(struct kvstore *kvstore,
 {
 	pthread_mutex_lock(&kvstore->lock);
 
-	char *filepath = kvstore_make_path(kvstore->namespace, key);
+	char *filepath = kvstore_make_path(kvstore->ns, key);
 	FILE *fp = fopen(filepath, "wb");
 	if (!fp) {
 		pthread_mutex_unlock(&kvstore->lock);
@@ -97,7 +97,7 @@ static int file_kvstore_read(struct kvstore *kvstore,
 {
 	pthread_mutex_lock(&kvstore->lock);
 
-	char *filepath = kvstore_make_path(kvstore->namespace, key);
+	char *filepath = kvstore_make_path(kvstore->ns, key);
 	FILE *fp = fopen(filepath, "rb");
 	if (!fp) {
 		pthread_mutex_unlock(&kvstore->lock);
@@ -139,18 +139,18 @@ static int file_kvstore_open(struct kvstore *kvstore, const char *ns)
 
 struct kvstore *nvs_kvstore_new(void)
 {
-	struct kvstore *kv = malloc(sizeof(*kv));
+	struct kvstore *kv = (struct kvstore *)malloc(sizeof(*kv));
 	if (!kv) {
 		return NULL;
 	}
 
-	kv->namespace = "build/config";
-	if (!kv->namespace) {
+	kv->ns = "build/config";
+	if (!kv->ns) {
 		free(kv);
 		return NULL;
 	}
 
-	if (file_kvstore_open(kv, kv->namespace) < 0) {
+	if (file_kvstore_open(kv, kv->ns) < 0) {
 		free(kv);
 		return NULL;
 	}

--- a/ports/host/wdt.c
+++ b/ports/host/wdt.c
@@ -130,6 +130,11 @@ int wdt_feed(struct wdt *self)
 	return 0;
 }
 
+bool wdt_is_enabled(const struct wdt *self)
+{
+	return self->enabled;
+}
+
 int wdt_enable(struct wdt *self)
 {
 	self->enabled = true;
@@ -174,9 +179,29 @@ int wdt_register_timeout_cb(wdt_timeout_cb_t cb, void *cb_ctx)
 	return 0;
 }
 
+uint32_t wdt_get_period(const struct wdt *self)
+{
+	return self->period_ms;
+}
+
+uint32_t wdt_get_time_since_last_feed(const struct wdt *self)
+{
+	return board_get_time_since_boot_ms() - self->last_feed_ms;
+}
+
 const char *wdt_name(const struct wdt *self)
 {
 	return self->name;
+}
+
+void wdt_foreach(wdt_foreach_cb_t cb, void *cb_ctx)
+{
+	struct list *p;
+
+	list_for_each(p, &m.list) {
+		struct wdt *wdt = list_entry(p, struct wdt, link);
+		(*cb)(wdt, cb_ctx);
+	}
 }
 
 int wdt_init(wdt_periodic_cb_t cb, void *cb_ctx)

--- a/projects/common.cmake
+++ b/projects/common.cmake
@@ -58,13 +58,22 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
 		-Wvector-operation-performance
 		-Wsuggest-attribute=pure
 		-Wsuggest-attribute=const
-		-Wsuggest-attribute=noreturn
 		-Wsuggest-attribute=format
-		-Wstack-usage=1024
-		-Wuseless-cast
-		-Wsuggest-final-types
-		-Wsuggest-final-methods
 	)
+	if (TARGET_PLATFORM STREQUAL "host")
+		list(APPEND COMMON_COMPILE_OPTIONS
+			-Wno-error=stack-protector
+			-Wno-error=missing-format-attribute
+		)
+	else()
+		list(APPEND COMMON_COMPILE_OPTIONS
+			-Wstack-usage=1024
+			-Wsuggest-attribute=noreturn
+			-Wuseless-cast
+			-Wsuggest-final-types
+			-Wsuggest-final-methods
+		)
+	endif()
 endif()
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 	# MSVC specific warning options (different from GCC/Clang)

--- a/src/app.c
+++ b/src/app.c
@@ -362,8 +362,9 @@ void app_init(struct app *app)
 #define CLI_MAX_HISTORY		10U
 	static char buf[CLI_CMD_MAXLEN * CLI_MAX_HISTORY];
 
-	DEFINE_CLI_CMD_LIST(commands, chg, config, help, idtag, info, log, net,
-			wifi, ocpp, reboot, metric, sec, xmodem);
+	DEFINE_CLI_CMD_LIST(commands,
+			help, exit, reboot, info, log, metric, dbg, config, net,
+			wifi, sec, xmodem, chg, idtag, ocpp);
 
 	cli_init(&m.cli, cli_io_create(), buf, sizeof(buf), app);
 	cli_register_cmdlist(&m.cli, commands);

--- a/src/charger/ocpp/adapter.c
+++ b/src/charger/ocpp/adapter.c
@@ -410,8 +410,8 @@ static void set_measurand_value(struct ocpp_SampledValue *p,
 		break;
 	case OCPP_MEASURAND_TEMPERATURE:
 		snprintf(p->value, sizeof(p->value), "%"PRId16".%02"PRId16,
-				v->temperature_centi / 100,
-				v->temperature_centi % 100);
+				(int16_t)(v->temperature_centi / 100),
+				(int16_t)(v->temperature_centi % 100));
 		break;
 	case OCPP_MEASURAND_SOC:
 		snprintf(p->value, sizeof(p->value), "%"PRIu8, v->soc_pct);

--- a/src/cli/cmd_config.c
+++ b/src/cli/cmd_config.c
@@ -488,6 +488,11 @@ out_help:
 static void do_reset_id(const struct cmd *cmd,
 		int argc, const char *argv[], void *ctx)
 {
+	unused(cmd);
+	unused(argc);
+	unused(argv);
+	unused(ctx);
+
 	config_reset("device.name");
 }
 

--- a/src/cli/cmd_debug.c
+++ b/src/cli/cmd_debug.c
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the Pazzk project <https://pazzk.net/>.
+ * Copyright (c) 2025 Pazzk <team@pazzk.net>.
+ *
+ * Community Version License (GPLv3):
+ * This software is open-source and licensed under the GNU General Public
+ * License v3.0 (GPLv3). You are free to use, modify, and distribute this code
+ * under the terms of the GPLv3. For more details, see
+ * <https://www.gnu.org/licenses/gpl-3.0.en.html>.
+ * Note: If you modify and distribute this software, you must make your
+ * modifications publicly available under the same license (GPLv3), including
+ * the source code.
+ *
+ * Commercial Version License:
+ * For commercial use, including redistribution or integration into proprietary
+ * systems, you must obtain a commercial license. This license includes
+ * additional benefits such as dedicated support and feature customization.
+ * Contact us for more details.
+ *
+ * Contact Information:
+ * Maintainer: 권경환 Kyunghwan Kwon (on behalf of the Pazzk Team)
+ * Email: k@pazzk.net
+ * Website: <https://pazzk.net/>
+ *
+ * Disclaimer:
+ * This software is provided "as-is", without any express or implied warranty,
+ * including, but not limited to, the implied warranties of merchantability or
+ * fitness for a particular purpose. In no event shall the authors or
+ * maintainers be held liable for any damages, whether direct, indirect,
+ * incidental, special, or consequential, arising from the use of this software.
+ */
+
+#include "helper.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "libmcu/compiler.h"
+#include "libmcu/wdt.h"
+#include "app.h"
+
+#if !defined(HOST_BUILD)
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#endif
+
+struct ctx {
+	const struct cli_io *io;
+	struct app *app;
+};
+
+static void on_each_wdt(struct wdt *wdt, void *ctx)
+{
+	struct ctx *p = (struct ctx *)ctx;
+	char buf[32];
+
+	printini(p->io, "wdt.name", wdt_name(wdt));
+	snprintf(buf, sizeof(buf), "%s", wdt_is_enabled(wdt)?
+			"enabled" : "disabled");
+	printini(p->io, "wdt.status", buf);
+	snprintf(buf, sizeof(buf), "%"PRIu32, wdt_get_period(wdt));
+	printini(p->io, "wdt.period", buf);
+	snprintf(buf, sizeof(buf), "%"PRIu32, wdt_get_time_since_last_feed(wdt));
+	printini(p->io, "wdt.time_since_last_feed", buf);
+}
+
+static void do_wdt(const struct cmd *cmd,
+		int argc, const char *argv[], void *ctx)
+{
+	unused(cmd);
+	unused(argc);
+	unused(argv);
+
+	wdt_foreach(on_each_wdt, ctx);
+}
+
+static void do_task(const struct cmd *cmd,
+		int argc, const char *argv[], void *ctx)
+{
+	unused(cmd);
+	unused(argc);
+	unused(argv);
+
+	struct ctx *p = (struct ctx *)ctx;
+	char *str = (char *)malloc(4096);
+
+	if (!str) {
+		println(p->io, "Failed to allocate memory for task list.");
+		return;
+	}
+
+#if !defined(HOST_BUILD)
+	vTaskList(str);
+	println(p->io, str);
+	vTaskGetRunTimeStats(str);
+	println(p->io, str);
+#endif
+
+	free(str);
+}
+
+static const struct cmd cmds[] = {
+	{ "wdt",  NULL, "dbg wdt",  2, 2, do_wdt },
+	{ "task", NULL, "dbg task", 2, 2, do_task },
+};
+
+DEFINE_CLI_CMD(dbg, "Debug commands") {
+	struct cli const *cli = (struct cli const *)env;
+	struct app *app = (struct app *)cli->env;
+	struct ctx ctx = { .io = cli->io, .app = app };
+
+	if (process_cmd(cmds, ARRAY_COUNT(cmds), argc, argv, &ctx)
+			!= CLI_CMD_SUCCESS) {
+		println(cli->io, "usage:");
+		for (size_t i = 0; i < ARRAY_COUNT(cmds); i++) {
+			print_help(cli->io, &cmds[i], NULL);
+		}
+	}
+
+	return CLI_CMD_SUCCESS;
+}

--- a/src/cli/cmd_info.c
+++ b/src/cli/cmd_info.c
@@ -30,7 +30,7 @@
  * incidental, special, or consequential, arising from the use of this software.
  */
 
-#include "libmcu/cli.h"
+#include "helper.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -56,15 +56,6 @@ typedef enum {
 			CMD_OPT_EVSE_ID |
 			CMD_OPT_SERIAL_NUMBER),
 } cmd_opt_t;
-
-static void printini(const struct cli_io *io,
-		const char *key, const char *value)
-{
-	io->write(key, strlen(key));
-	io->write("=", 1);
-	io->write(value, strlen(value));
-	io->write("\n", 1);
-}
 
 static cmd_opt_t get_command_option(int argc, const char *opt)
 {

--- a/src/cli/cmd_wifi.c
+++ b/src/cli/cmd_wifi.c
@@ -161,7 +161,7 @@ static void do_list(const struct cmd *cmd,
 	unused(argv);
 
 	struct ctx *p = (struct ctx *)ctx;
-	struct wifi_ap_info *ap_list =
+	struct wifi_ap_info *ap_list = (struct wifi_ap_info *)
 		malloc(sizeof(*ap_list) * WIFI_AP_INFO_MAX_COUNT);
 	if (!ap_list) {
 		println(p->io, "Failed to allocate memory for AP list");

--- a/src/driver/lis2dw12.c
+++ b/src/driver/lis2dw12.c
@@ -130,7 +130,7 @@ int lis2dw12_set_mode(lis2dw12_mode_t mode, lis2dw12_odr_t odr)
 		break;
 	}
 
-	reg |= odr << 4;
+	reg |= (uint8_t)(odr << 4);
 
 	return write_reg(CTRL1, reg);
 }

--- a/src/net/wifi_ap_info.c
+++ b/src/net/wifi_ap_info.c
@@ -33,6 +33,7 @@
 #include "net/wifi_ap_info.h"
 #include <errno.h>
 #include "fs/fs.h"
+#include "libmcu/compiler.h"
 
 static const char *info_path = "wifi/ap_list";
 

--- a/src/safety/safety.c
+++ b/src/safety/safety.c
@@ -80,7 +80,8 @@ static int add_entry(struct safety *self, struct safety_entry *entry)
 		return -EALREADY;
 	}
 
-	if (!(container = malloc(sizeof(struct entry_container)))) {
+	if (!(container = (struct entry_container *)
+			malloc(sizeof(struct entry_container)))) {
 		return -ENOMEM;
 	}
 
@@ -191,7 +192,7 @@ struct safety *safety_create(void)
 {
 	struct safety *self;
 
-	if (!(self = malloc(sizeof(struct safety)))) {
+	if (!(self = (struct safety *)malloc(sizeof(struct safety)))) {
 		return NULL;
 	}
 


### PR DESCRIPTION
This pull request includes several updates to the codebase, focusing on submodule updates, command-line interface (CLI) improvements, and the addition of new debugging functionality. The most significant changes include updating the `libmcu` submodule, reordering CLI commands, introducing a new `dbg` CLI command with debugging utilities, and removing redundant code.

### Submodule Update:
* Updated the `libmcu` submodule to a new commit (`93bebd9bc405dbfa1abc7686642f3c510bfa48c8`) for incorporating the latest changes.

### CLI Improvements:
* Reordered the CLI command list in `src/app.c` for better organization and usability. Commands like `help`, `exit`, and `reboot` now appear earlier in the list, while others such as `chg` and `ocpp` are placed later.

### Debugging Functionality:
* Added a new `dbg` CLI command in `src/cli/cmd_debug.c` with subcommands `wdt` (for watchdog timer information) and `task` (for FreeRTOS task details). This includes memory allocation for task statistics and printing watchdog timer states.

### Code Simplification:
* Removed the `printini` helper function from `src/cli/cmd_info.c` as it is now included in the shared `helper.h` file, reducing redundancy.
* Updated the include directive in `src/cli/cmd_info.c` to use the shared `helper.h` header file for centralized utility functions.