### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-on-host:
+    permissions:
+      contents: read
     name: Build on Host
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/pazzk-labs/evse/security/code-scanning/9](https://github.com/pazzk-labs/evse/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the `build-on-host` job. Since this job only clones the repository and performs local build operations, it only requires `contents: read` permission. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for this job, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
