### PR TITLE
fix(connector): correct output power state check logic

### DIFF
--- a/tests/mocks/uptime.cpp
+++ b/tests/mocks/uptime.cpp
@@ -1,0 +1,10 @@
+#include "CppUTestExt/MockSupport.h"
+#include "uptime.h"
+
+time_t uptime_get(void) {
+	return (time_t)mock().actualCall(__func__).returnLongLongIntValue();
+}
+
+void uptime_init(void) {
+	mock().actualCall(__func__);
+}

--- a/tests/runners/charger/free/connector.mk
+++ b/tests/runners/charger/free/connector.mk
@@ -43,6 +43,7 @@ TEST_SRC_FILES = \
 	stubs/logger.c \
 	mocks/metering.cpp \
 	mocks/iec61851.cpp \
+	mocks/uptime.cpp \
 	../external/libmcu/tests/stubs/metrics.cpp \
 
 INCLUDE_DIRS = \

--- a/tests/runners/charger/ocpp/connector.mk
+++ b/tests/runners/charger/ocpp/connector.mk
@@ -50,6 +50,7 @@ TEST_SRC_FILES = \
 	mocks/csms.cpp \
 	mocks/ocpp.cpp \
 	mocks/uid.cpp \
+	mocks/uptime.cpp \
 	../external/libmcu/tests/mocks/assert.cpp \
 	../external/libmcu/tests/stubs/metrics.cpp \
 	../external/libmcu/tests/stubs/bitops.cpp \

--- a/tests/src/charger/free/connector_test.cpp
+++ b/tests/src/charger/free/connector_test.cpp
@@ -294,6 +294,7 @@ TEST(FreeConnector, ShouldGoStateFWithEvent_WhenEVSEErrorInStateC) {
 	// connector_is_evse_error
 	mock().expectOneCall("iec61851_get_pwm_duty_target").andReturnValue(53);
 	mock().expectOneCall("safety_check").ignoreOtherParameters().andReturnValue(1);
+	mock().expectOneCall("uptime_get").ignoreOtherParameters().andReturnValue(10);
 	// do_evse_error
 	mock().expectOneCall("iec61851_is_supplying_power").andReturnValue(true);
 	mock().expectOneCall("iec61851_stop_power_supply");


### PR DESCRIPTION
This pull request introduces changes to enhance the safety checks in the EVSE (Electric Vehicle Supply Equipment) error handling logic and adds support for uptime-based conditions. Key updates include modifications to the `connector.c` logic, integration of the `uptime` module, and updates to the test suite to include mocks and test cases for the new functionality.

### Enhancements to EVSE error handling logic:
* Updated `connector_is_evse_error` to include a new condition that checks uptime against an initial stabilization period (`INITIAL_STABILIZATION_SEC`) before determining an error state. This ensures that transient conditions during startup are ignored. (`[src/charger/connector.cL219-R221](diffhunk://#diff-7fb2406ef263148ae74ba9edefc8b87939d0104072ab51b51b1c82e9638ca072L219-R221)`)
* Fixed a typo in the `is_output_power_ok` function by correcting the safety context name from `"ip"` to `"op"`. (`[src/charger/connector.cL96-R97](diffhunk://#diff-7fb2406ef263148ae74ba9edefc8b87939d0104072ab51b51b1c82e9638ca072L96-R97)`)

### Integration of the `uptime` module:
* Added the `uptime.h` header to `connector.c` to enable uptime-related functionality. (`[src/charger/connector.cR41](diffhunk://#diff-7fb2406ef263148ae74ba9edefc8b87939d0104072ab51b51b1c82e9638ca072R41)`)
* Implemented `uptime_get` and `uptime_init` mock functions in `mocks/uptime.cpp` to simulate uptime behavior in tests. (`[tests/mocks/uptime.cppR1-R10](diffhunk://#diff-4d5cc47d93e48010cb36dafe30e17cb1d686c7ebbfd47e78a2b672619cd95261R1-R10)`)

### Updates to the test suite:
* Included `mocks/uptime.cpp` in the test runners for both `free` and `ocpp` connectors to enable testing of uptime-related logic. (`[[1]](diffhunk://#diff-e9bf4c7a7db42300b6d7d64c59f21ef4a29ddadc8ad93148e97c41511565c43dR46)`, `[[2]](diffhunk://#diff-62118849caa6788f4598eb0e5fe494e76c87e66bc3c41a41d4a03cb5f13f9627R53)`)
* Added a mock expectation for `uptime_get` in the `FreeConnector` test case to validate the new uptime-based condition in the EVSE error logic. (`[tests/src/charger/free/connector_test.cppR297](diffhunk://#diff-911da76ad917ab2503d63e9a1aec6b1eb55229aa46dccd768a0794415a1de538R297)`)