### PR TITLE
fix(cli): improve error handling in log file reading

### DIFF
--- a/src/cli/cmd_log.c
+++ b/src/cli/cmd_log.c
@@ -103,8 +103,10 @@ static void print_log(struct logfs *fs, const char *filename, struct cli *cli)
 
 	for (size_t i = 0; i < filesize; i += (size_t)len) {
 		len = logfs_read(fs, ts, i, buf, blocksize);
-		if (len < 0) {
-			println(cli->io, "Failed to read file");
+		if (len <= 0) {
+			snprintf(buf, blocksize, "Failed to read at %zu/%zu",
+					i, filesize);
+			println(cli->io, buf);
 			break;
 		}
 		cli->io->write(buf, (size_t)len);


### PR DESCRIPTION
This pull request includes a small but important change to the `print_log` function in `src/cli/cmd_log.c`. The change improves error handling by providing more detailed feedback when a file read operation fails.

* [`src/cli/cmd_log.c`](diffhunk://#diff-ccac08d630541a7a33acb5b6608ffcb966584fab117a3a420c6f2869945f1163L106-R109): Updated the `print_log` function to include the specific offset and total file size in the error message when a read operation fails. This replaces the generic "Failed to read file" message, making debugging easier.