### PR TITLE
chore(netmgr): adjust timeout and retry backoff values

### DIFF
--- a/include/net/netmgr.h
+++ b/include/net/netmgr.h
@@ -44,10 +44,10 @@ extern "C" {
 #define NETMGR_CONNECT_TIMEOUT_MS		(10U * 1000)
 #endif
 #if !defined(NETMGR_MAX_RETRY)
-#define NETMGR_MAX_RETRY			200U /* about 10 hours */
+#define NETMGR_MAX_RETRY			200U /* about 16 hours */
 #endif
 #if !defined(NETMGR_MAX_BACKOFF_MS)
-#define NETMGR_MAX_BACKOFF_MS			(180U * 1000) /* 3min */
+#define NETMGR_MAX_BACKOFF_MS			(300U * 1000) /* 5min */
 #endif
 
 /**


### PR DESCRIPTION
This pull request updates timeout and retry configuration constants in the `netmgr.h` file to extend the maximum retry duration and backoff interval. These changes aim to improve the resilience of the network manager.

### Configuration updates:
* [`NETMGR_MAX_RETRY`](diffhunk://#diff-5a9523f419e902f0722a7526fde5d8da14017c7e60ebd9835852b5fd470d9df8L47-R50): Increased the maximum retry count from 200 (10 hours) to 200 (16 hours) to allow for a longer retry duration.
* [`NETMGR_MAX_BACKOFF_MS`](diffhunk://#diff-5a9523f419e902f0722a7526fde5d8da14017c7e60ebd9835852b5fd470d9df8L47-R50): Increased the maximum backoff interval from 180,000 ms (3 minutes) to 300,000 ms (5 minutes) to provide a more gradual retry mechanism.