### PR TITLE
feat(netmgr): add callback for unrecoverable network errors

### DIFF
--- a/include/net/netmgr.h
+++ b/include/net/netmgr.h
@@ -81,6 +81,18 @@ typedef uint8_t netmgr_state_mask_t;
 typedef void (*netmgr_event_cb_t)(const netmgr_state_t event, void *ctx);
 
 /**
+ * @typedef netmgr_unrecoverable_cb_t
+ * @brief Callback type for handling unrecoverable network errors.
+ *
+ * This callback is invoked when the network manager encounters an
+ * unrecoverable error. It allows the application to perform custom
+ * error handling or recovery actions.
+ *
+ * @param[in] ctx User-defined context passed to the callback.
+ */
+typedef void (*netmgr_unrecoverable_cb_t)(void *ctx);
+
+/**
  * @brief Typedef for a network manager task function.
  *
  * This type defines a function pointer for a task that can be registered with
@@ -138,6 +150,20 @@ int netmgr_enable(void);
  * @return 0 on success, or a negative error code on failure.
  */
 int netmgr_disable(void);
+
+/**
+ * @brief Registers a callback for unrecoverable network errors.
+ *
+ * This function allows the application to register a callback that will
+ * be invoked when the network manager encounters an unrecoverable error.
+ * The callback can be used to handle the error or perform recovery actions.
+ *
+ * @param[in] cb The callback function to handle unrecoverable errors.
+ * @param[in] ctx User-defined context to pass to the callback.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int netmgr_register_unrecoverable_cb(netmgr_unrecoverable_cb_t cb, void *ctx);
 
 /**
  * @brief Register a network interface with the network manager.

--- a/include/net/netmgr.h
+++ b/include/net/netmgr.h
@@ -44,10 +44,10 @@ extern "C" {
 #define NETMGR_CONNECT_TIMEOUT_MS		(10U * 1000)
 #endif
 #if !defined(NETMGR_MAX_RETRY)
-#define NETMGR_MAX_RETRY			200U /* about 16 hours */
+#define NETMGR_MAX_RETRY			200U /* about 10 hours */
 #endif
 #if !defined(NETMGR_MAX_BACKOFF_MS)
-#define NETMGR_MAX_BACKOFF_MS			(300U * 1000) /* 5min */
+#define NETMGR_MAX_BACKOFF_MS			(180U * 1000) /* 3min */
 #endif
 
 /**


### PR DESCRIPTION
This pull request introduces enhancements to the network manager (`netmgr`) by adding support for handling unrecoverable errors through a new callback mechanism, along with adjustments to retry and backoff configurations. The most important changes include defining a new callback type and registration function for unrecoverable errors, modifying the behavior of the error state handler, and updating retry/backoff constants for improved performance.

### Enhancements to error handling:

* Added a new typedef `netmgr_unrecoverable_cb_t` for handling unrecoverable network errors, along with documentation explaining its purpose and usage (`include/net/netmgr.h`).
* Introduced the `netmgr_register_unrecoverable_cb` function to allow applications to register a callback for unrecoverable errors, enabling custom error handling or recovery (`include/net/netmgr.h`, `src/net/netmgr.c`). [[1]](diffhunk://#diff-5a9523f419e902f0722a7526fde5d8da14017c7e60ebd9835852b5fd470d9df8R154-R167) [[2]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R944-R951)
* Updated the `do_reset` function to invoke the registered unrecoverable error callback instead of directly rebooting the system, providing more flexibility in error recovery (`src/net/netmgr.c`).

### Configuration updates:

* Reduced `NETMGR_MAX_BACKOFF_MS` from 5 minutes to 3 minutes and clarified the comment for `NETMGR_MAX_RETRY` to reflect that it corresponds to approximately 10 hours, improving retry/backoff behavior (`include/net/netmgr.h`).

### Internal changes:

* Added `unrecoverable_cb` and `unrecoverable_ctx` fields to the `netmgr` structure to store the callback and its context for handling unrecoverable errors (`src/net/netmgr.c`).
* Removed an unused `#include "app.h"` directive to clean up the codebase (`src/net/netmgr.c`).