### PR TITLE
feat(netmgr): add mutex for thread safety

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
-1148705	 230748	2491885	3871338	 3b126a	build/EVSE.elf
+1149005	 230796	2491885	3871686	 3b13c6	build/EVSE.elf

--- a/ports/esp-idf/ws.c
+++ b/ports/esp-idf/ws.c
@@ -372,6 +372,7 @@ struct server *ws_create_server(const struct ws_param *param,
 		NETMGR_STATE_CONNECTED | NETMGR_STATE_DISCONNECTED;
 	if (netmgr_register_event_cb(event_mask, on_net_event, &ws) != 0) {
 		esp_websocket_client_destroy(ws.handle);
+		error("Failed to register network event callback.");
 		return NULL;
 	}
 


### PR DESCRIPTION
This pull request introduces thread-safety improvements to the `netmgr` module by adding a mutex to protect shared resources and ensuring proper synchronization across multiple threads. The changes primarily focus on preventing race conditions by locking and unlocking the mutex in critical sections of the code.

### Thread-Safety Enhancements:

* **Mutex Addition:**
  - Added a `pthread_mutex_t mutex` field to the `netmgr` structure to facilitate thread synchronization. (`src/net/netmgr.c`, [src/net/netmgr.cR126](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R126))
  - Initialized the mutex in the `netmgr_init` function and ensured proper cleanup in `netmgr_deinit`. (`src/net/netmgr.c`, [[1]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R1022) [[2]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R1055-R1058)

* **Critical Section Protection:**
  - Wrapped critical sections in `pthread_mutex_lock` and `pthread_mutex_unlock` to ensure thread-safe access to shared resources in multiple functions:
    - `netmgr_connected`, `netmgr_state`, and `netmgr_ping` for checking connection state and performing operations. (`src/net/netmgr.c`, [src/net/netmgr.cL844-R884](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17L844-R884))
    - `netmgr_register_task`, `netmgr_register_event_cb`, and `netmgr_register_iface` for safely modifying internal lists. (`src/net/netmgr.c`, [[1]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R901-R903) [[2]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R926-R928) [[3]](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R966-R1008)
    - `netmgr_enable` and `netmgr_disable` for safely enabling and disabling the network manager. (`src/net/netmgr.c`, [src/net/netmgr.cR966-R1008](diffhunk://#diff-e1e1b7bd7862444a0a4238547a819da7ee9c8ee9e3c7e764b1da022c4af0bf17R966-R1008))

These changes ensure that the `netmgr` module operates correctly in a multithreaded environment, preventing potential data corruption or undefined behavior caused by concurrent access to shared resources.