### PR TITLE
feat(server): track server downtime and update websocket version

### DIFF
--- a/.github/memsize.baseline
+++ b/.github/memsize.baseline
@@ -1,2 +1,2 @@
    text	   data	    bss	    dec	    hex	filename
-1149005	 230796	2491885	3871686	 3b13c6	build/EVSE.elf
+1149741	 230908	2491885	3872534	 3b1716	build/EVSE.elf

--- a/include/net/server.h
+++ b/include/net/server.h
@@ -52,36 +52,133 @@ struct server_api {
 			const void *data, const size_t datasize);
 	int (*recv)(struct server *self, void *buf, const size_t bufsize);
 	bool (*connected)(const struct server *self);
+	uint32_t (*downtime)(const struct server *self);
 };
 
+/**
+ * @brief Enable the server.
+ *
+ * This function activates the server, allowing it to start processing
+ * requests. It ensures that the server is properly initialized and
+ * ready for operation.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 static inline int server_enable(struct server *self) {
 	return ((struct server_api *)self)->enable(self);
 }
 
+/**
+ * @brief Disable the server.
+ *
+ * This function deactivates the server, stopping it from processing
+ * any further requests. It ensures that the server is properly
+ * shut down and transitions to an inactive state.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 static inline int server_disable(struct server *self) {
 	return ((struct server_api *)self)->disable(self);
 }
 
+/**
+ * @brief Establish a connection to the server.
+ *
+ * This function attempts to connect the server to its designated
+ * network or endpoint. It ensures that the server is in a connected
+ * state and ready to handle requests.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 static inline int server_connect(struct server *self) {
 	return ((struct server_api *)self)->connect(self);
 }
 
+/**
+ * @brief Disconnect the server.
+ *
+ * This function disconnects the server from its network or endpoint,
+ * transitioning it to an offline state. It ensures that all resources
+ * related to the connection are properly released.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 static inline int server_disconnect(struct server *self) {
 	return ((struct server_api *)self)->disconnect(self);
 }
 
+/**
+ * @brief Send data through the server.
+ *
+ * This function sends the specified data through the server's
+ * connection. It ensures that the data is transmitted to the
+ * intended recipient.
+ *
+ * @param[in] self Pointer to the server structure.
+ * @param[in] data Pointer to the data to be sent.
+ * @param[in] datasize Size of the data to be sent, in bytes.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 static inline int server_send(struct server *self,
 		const void *data, const size_t datasize) {
 	return ((struct server_api *)self)->send(self, data, datasize);
 }
 
+/**
+ * @brief Receive data from the server.
+ *
+ * This function receives data from the server's connection and stores
+ * it in the provided buffer. It ensures that the received data does
+ * not exceed the buffer size.
+ *
+ * @param[in] self Pointer to the server structure.
+ * @param[out] buf Pointer to the buffer where received data will be stored.
+ * @param[in] bufsize Size of the buffer, in bytes.
+ *
+ * @return Number of bytes received on success, or a negative error code on
+ *         failure.
+ */
 static inline int server_recv(struct server *self,
 		void *buf, const size_t bufsize) {
 	return ((struct server_api *)self)->recv(self, buf, bufsize);
 }
 
+/**
+ * @brief Check if the server is connected.
+ *
+ * This function determines whether the server is currently connected
+ * by evaluating its internal state.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return true if the server is connected, false otherwise.
+ */
 static inline bool server_connected(const struct server *self) {
 	return ((const struct server_api *)self)->connected(self);
+}
+
+/**
+ * @brief Calculate the downtime of the server.
+ *
+ * This function computes the duration for which the server has been
+ * continuously offline. If the server is currently online, the
+ * downtime is reset and this function will return 0.
+ *
+ * @param[in] self Pointer to the server structure.
+ *
+ * @return The continuous downtime of the server in seconds.
+ */
+static inline uint32_t server_downtime(const struct server *self) {
+	return ((const struct server_api *)self)->downtime(self);
 }
 
 #if defined(__cplusplus)

--- a/ports/esp-idf/websocket/CHANGELOG.md
+++ b/ports/esp-idf/websocket/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [1.5.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.5.0)
+
+### Features
+
+- add separate tx lock for send and receive ([250eebf](https://github.com/espressif/esp-protocols/commit/250eebf))
+- add unregister event to websocket client ([ce16050](https://github.com/espressif/esp-protocols/commit/ce16050))
+- add ability to reconnect after close ([19891d8](https://github.com/espressif/esp-protocols/commit/19891d8))
+
+### Bug Fixes
+
+- release client-lock during WEBSOCKET_EVENT_DATA ([030cb75](https://github.com/espressif/esp-protocols/commit/030cb75))
+
+## [1.4.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.4.0)
+
+### Features
+
+- Support DS peripheral for mutual TLS ([55385ec3](https://github.com/espressif/esp-protocols/commit/55385ec3))
+
+### Bug Fixes
+
+- wait for task on destroy ([42674b49](https://github.com/espressif/esp-protocols/commit/42674b49))
+- Fix pytest to verify client correctly ([9046af8f](https://github.com/espressif/esp-protocols/commit/9046af8f))
+- propagate error type ([eeeb9006](https://github.com/espressif/esp-protocols/commit/eeeb9006))
+- fix example buffer leak ([5219c39d](https://github.com/espressif/esp-protocols/commit/5219c39d))
+
+### Updated
+
+- chore(websocket): align structure members ([beb6e57e](https://github.com/espressif/esp-protocols/commit/beb6e57e))
+- chore(websocket): remove unused client variable ([15d3a01e](https://github.com/espressif/esp-protocols/commit/15d3a01e))
+
 ## [1.3.0](https://github.com/espressif/esp-protocols/commits/websocket-v1.3.0)
 
 ### Features

--- a/ports/esp-idf/websocket/Kconfig
+++ b/ports/esp-idf/websocket/Kconfig
@@ -7,4 +7,17 @@ menu "ESP WebSocket client"
             Enable this option will reallocated buffer when send or receive data and free them when end of use.
             This can save about 2 KB memory when no websocket data send and receive.
 
+    config ESP_WS_CLIENT_SEPARATE_TX_LOCK
+        bool "Enable separate tx lock for send and receive data"
+        default n
+        help
+            Enable this option will use separate lock for send and receive data.
+            This can avoid the lock contention when send and receive data at the same time.
+
+    config ESP_WS_CLIENT_TX_LOCK_TIMEOUT_MS
+        int "TX lock timeout in milliseconds"
+        depends on ESP_WS_CLIENT_SEPARATE_TX_LOCK
+        default 2000
+        help
+            Timeout for acquiring the TX lock when using separate TX lock.
 endmenu

--- a/ports/esp-idf/websocket/idf_component.yml
+++ b/ports/esp-idf/websocket/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.0"
+version: "1.5.0"
 description: WebSocket protocol client for ESP-IDF
 url: https://github.com/espressif/esp-protocols/tree/master/components/esp_websocket_client
 dependencies:

--- a/ports/esp-idf/websocket/include/esp_websocket_client.h
+++ b/ports/esp-idf/websocket/include/esp_websocket_client.h
@@ -48,7 +48,8 @@ typedef enum {
     WEBSOCKET_ERROR_TYPE_NONE = 0,
     WEBSOCKET_ERROR_TYPE_TCP_TRANSPORT,
     WEBSOCKET_ERROR_TYPE_PONG_TIMEOUT,
-    WEBSOCKET_ERROR_TYPE_HANDSHAKE
+    WEBSOCKET_ERROR_TYPE_HANDSHAKE,
+    WEBSOCKET_ERROR_TYPE_SERVER_CLOSE
 } esp_websocket_error_type_t;
 
 /**
@@ -101,6 +102,7 @@ typedef struct {
     const char                  *password;                  /*!< Using for Http authentication */
     const char                  *path;                      /*!< HTTP Path, if not set, default is `/` */
     bool                        disable_auto_reconnect;     /*!< Disable the automatic reconnect function when disconnected */
+    bool                        enable_close_reconnect;     /*!< Enable reconnect after server close */
     void                        *user_context;              /*!< HTTP user data context */
     int                         task_prio;                  /*!< Websocket task priority */
     const char                 *task_name;                  /*!< Websocket task name */
@@ -108,10 +110,13 @@ typedef struct {
     int                         buffer_size;                /*!< Websocket buffer size */
     const char                  *cert_pem;                  /*!< Pointer to certificate data in PEM or DER format for server verify (with SSL), default is NULL, not required to verify the server. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in cert_len. */
     size_t                      cert_len;                   /*!< Length of the buffer pointed to by cert_pem. May be 0 for null-terminated pem */
-    const char                  *client_cert;               /*!< Pointer to certificate data in PEM or DER format for SSL mutual authentication, default is NULL, not required if mutual authentication is not needed. If it is not NULL, also `client_key` has to be provided. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in client_cert_len. */
+    const char                  *client_cert;               /*!< Pointer to certificate data in PEM or DER format for SSL mutual authentication, default is NULL, not required if mutual authentication is not needed. If it is not NULL, also `client_key` or `client_ds_data` (if supported) has to be provided. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in client_cert_len. */
     size_t                      client_cert_len;            /*!< Length of the buffer pointed to by client_cert. May be 0 for null-terminated pem */
-    const char                  *client_key;                /*!< Pointer to private key data in PEM or DER format for SSL mutual authentication, default is NULL, not required if mutual authentication is not needed. If it is not NULL, also `client_cert` has to be provided. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in client_key_len */
+    const char                  *client_key;                /*!< Pointer to private key data in PEM or DER format for SSL mutual authentication, default is NULL, not required if mutual authentication is not needed. If it is not NULL, also `client_cert` has to be provided and `client_ds_data` (if supported) gets ignored. PEM-format must have a terminating NULL-character. DER-format requires the length to be passed in client_key_len */
     size_t                      client_key_len;             /*!< Length of the buffer pointed to by client_key_pem. May be 0 for null-terminated pem */
+#if CONFIG_ESP_TLS_USE_DS_PERIPHERAL
+    void                        *client_ds_data;            /*!< Pointer to the encrypted private key data for SSL mutual authentication using the DS peripheral, default is NULL, not required if mutual authentication is not needed. If it is not NULL, also `client_cert` has to be provided. It is ignored if `client_key` is provided */
+#endif
     esp_websocket_transport_t   transport;                  /*!< Websocket transport type, see `esp_websocket_transport_t */
     const char                  *subprotocol;               /*!< Websocket subprotocol */
     const char                  *user_agent;                /*!< Websocket user-agent */
@@ -456,6 +461,18 @@ esp_err_t esp_websocket_register_events(esp_websocket_client_handle_t client,
                                         esp_websocket_event_id_t event,
                                         esp_event_handler_t event_handler,
                                         void *event_handler_arg);
+
+/**
+ * @brief Unegister the Websocket Events
+ *
+ * @param client            The client handle
+ * @param event             The event id
+ * @param event_handler     The callback function
+ * @return esp_err_t
+ */
+esp_err_t esp_websocket_unregister_events(esp_websocket_client_handle_t client,
+                                          esp_websocket_event_id_t event,
+                                          esp_event_handler_t event_handler);
 
 #ifdef __cplusplus
 }

--- a/ports/esp-idf/ws.c
+++ b/ports/esp-idf/ws.c
@@ -35,6 +35,7 @@
 
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include "esp_websocket_client.h"
 #include "libmcu/retry.h"
@@ -67,6 +68,7 @@ struct ws_server {
 	struct apptmr *timer;
 	struct ringbuf *rxq;
 
+	time_t offline; /* the time when the server connection was lost */
 	uint32_t timestamp;
 	int error_count;
 	bool enabled;
@@ -182,9 +184,13 @@ static void on_ws_event(void *ctx,
 		break;
 	case WEBSOCKET_EVENT_CONNECTED:
 		apptmr_stop(ws->timer);
+		ws->offline = 0; /* reset offline time */
 		info("websocket event connected");
 		break;
 	case WEBSOCKET_EVENT_DISCONNECTED:
+		if (!ws->offline) { /* Prevents duplicate events from affecting offline time */
+			ws->offline = time(NULL);
+		}
 		info("websocket event disconnected");
 		break;
 	case WEBSOCKET_EVENT_FINISH: /* fall through */
@@ -198,7 +204,6 @@ static void on_ws_event(void *ctx,
 		error("websocket event: %d", event_id);
 		break;
 	case WEBSOCKET_EVENT_DATA:
-		info("ws opcode=%d, len=%u", data->op_code, data->data_len);
 		if (data->op_code == 0x08 && data->data_len == 2) {
 			info("Received closed message with code=%d",
 				256 * data->data_ptr[0] + data->data_ptr[1]);
@@ -273,6 +278,17 @@ static int disconnect_from_server(struct server *srv)
 	return -ENOTSUP;
 }
 
+static uint32_t downtime(const struct server *srv)
+{
+	const struct ws_server *ws = (const struct ws_server *)srv;
+
+	if (!ws->enabled || connected(srv)) {
+		return 0;
+	}
+
+	return (uint32_t)(time(NULL) - ws->offline);
+}
+
 static int enable(struct server *srv)
 {
 	struct ws_server *ws = (struct ws_server *)srv;
@@ -281,6 +297,7 @@ static int enable(struct server *srv)
 
 	if (err == ESP_OK) {
 		ws->enabled = true;
+		ws->offline = time(NULL);
 		return 0;
 	}
 
@@ -344,6 +361,7 @@ struct server *ws_create_server(const struct ws_param *param,
 			.send = send_data,
 			.recv = recv_data,
 			.connected = connected,
+			.downtime = downtime,
 		},
 	};
 
@@ -365,14 +383,7 @@ struct server *ws_create_server(const struct ws_param *param,
 	}
 
 	if (init(&ws) != 0) {
-		return NULL;
-	}
-
-	const netmgr_state_mask_t event_mask =
-		NETMGR_STATE_CONNECTED | NETMGR_STATE_DISCONNECTED;
-	if (netmgr_register_event_cb(event_mask, on_net_event, &ws) != 0) {
-		esp_websocket_client_destroy(ws.handle);
-		error("Failed to register network event callback.");
+		error("Failed to initialize WebSocket client.");
 		return NULL;
 	}
 
@@ -386,6 +397,20 @@ struct server *ws_create_server(const struct ws_param *param,
 
 	ws.timer = apptmr_create(false, on_timeout, &ws);
 	apptmr_enable(ws.timer);
+
+	const netmgr_state_mask_t event_mask =
+		NETMGR_STATE_CONNECTED | NETMGR_STATE_DISCONNECTED;
+	if (netmgr_register_event_cb(event_mask, on_net_event, &ws) != 0) {
+		esp_websocket_client_destroy(ws.handle);
+		error("Failed to register network event callback.");
+		return NULL;
+	}
+
+	if (netmgr_connected()) { /* Called when already connected */
+		on_net_event(NETMGR_STATE_CONNECTED, &ws);
+	}
+
+	info("WebSocket client initialized with URL: %s", ws.param.url);
 
 	return (struct server *)&ws;
 }

--- a/src/charger/extension_ocpp.c
+++ b/src/charger/extension_ocpp.c
@@ -36,6 +36,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include "ocpp/csms.h"
 #include "updater.h"
@@ -262,8 +263,14 @@ static int ext_post_process(struct charger *self)
 	const ocpp_charger_reboot_t req =
 		ocpp_charger_get_pending_reboot_type(self);
 
-	if (req != OCPP_CHARGER_REBOOT_NONE &&
-			ocpp_count_pending_requests() == 0) {
+	if (req == OCPP_CHARGER_REBOOT_NONE) {
+		if (csms_downtime() > CSMS_REBOOT_TRIGGER_DOWNTIME_SEC) {
+			error("CSMS is down for too long: %"PRIu32" seconds",
+					csms_downtime());
+			ocpp_charger_request_reboot(self,
+					OCPP_CHARGER_REBOOT_REQUIRED);
+		}
+	} else if (ocpp_count_pending_requests() == 0) {
 		if (req == OCPP_CHARGER_REBOOT_REQUIRED) { /* triggered by DFU.
 						Do not reboot during charging */
 			bool charging = false;

--- a/src/charger/ocpp/csms.c
+++ b/src/charger/ocpp/csms.c
@@ -153,6 +153,11 @@ static void on_ocpp_event(ocpp_event_t event_type,
 	}
 }
 
+uint32_t csms_downtime(void)
+{
+	return server_downtime(csms);
+}
+
 bool csms_is_up(void)
 {
 	return server_connected(csms);

--- a/src/charger/ocpp/csms.h
+++ b/src/charger/ocpp/csms.h
@@ -39,6 +39,10 @@ extern "C" {
 
 #include "ocpp/ocpp.h"
 
+#if !defined(CSMS_DOWNTIME_MAX_SEC)
+#define CSMS_REBOOT_TRIGGER_DOWNTIME_SEC	(60 * 60 * 24U) /* 1 day */
+#endif
+
 int csms_init(void *ctx);
 int csms_request(const ocpp_message_t msgtype, void *ctx, void *opt);
 int csms_request_defer(const ocpp_message_t msgtype, void *ctx, void *opt,
@@ -47,6 +51,7 @@ int csms_response(const ocpp_message_t msgtype,
 		const struct ocpp_message *req, void *ctx, void *opt);
 bool csms_is_up(void);
 int csms_reconnect(const uint32_t delay_sec);
+uint32_t csms_downtime(void);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This pull request introduces functionality to track server downtime and enhances the `server` API with new inline functions and documentation. The most important changes include adding a `downtime` method to the `server_api` structure, updating the `ws_server` structure to store offline time, and implementing logic to calculate downtime in the WebSocket server.

### Enhancements to the `server` API:
* Added a `downtime` method to the `server_api` structure to calculate the duration for which the server has been offline. (`include/net/server.h`, [include/net/server.hR56-R184](diffhunk://#diff-68a547c8aa2a020130e4eabd2096b2a79738e4a2c4b080c28ecad2e9c0d82ec3R56-R184))
* Introduced an inline function `server_downtime` to expose the `downtime` method in the `server` API. This function calculates server downtime in seconds. (`include/net/server.h`, [include/net/server.hR56-R184](diffhunk://#diff-68a547c8aa2a020130e4eabd2096b2a79738e4a2c4b080c28ecad2e9c0d82ec3R56-R184))

### WebSocket server enhancements:
* Updated the `ws_server` structure to include a new `offline` field to track the time when the server connection was lost. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR70](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR70))
* Implemented logic in the WebSocket event handler to reset the offline time when the server connects and set it when the server disconnects. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR186-R192](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR186-R192))
* Added the `downtime` method implementation for the WebSocket server to calculate the offline duration based on the `offline` field. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR281-R289](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR281-R289))
* Updated the `enable` method to initialize the `offline` field when the server is enabled. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR298](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR298))
* Registered the `downtime` method in the `server_api` structure during WebSocket server creation. (`ports/esp-idf/ws.c`, [ports/esp-idf/ws.cR362](diffhunk://#diff-22f1bb1a310ff2cb66a8234da98d49541ba66bed67134d9daa558c3e55487f4dR362))