### PR TITLE
feat(docs): remove 'development_board'

### DIFF
--- a/docs/website/source/index.rst
+++ b/docs/website/source/index.rst
@@ -21,7 +21,6 @@ Pazzk는 인증서 기반 통신, 실시간성 제어, 유지보수 가능한 �
 
    quickstart
    cli/cli_commands
-   development_board
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This pull request makes a minor documentation update by removing the `development_board` entry from the table of contents in the `index.rst` file.